### PR TITLE
feat: add functionality to set subtitle font

### DIFF
--- a/GI-Subtitles/Config.json
+++ b/GI-Subtitles/Config.json
@@ -10,5 +10,6 @@
   "AutoStart": false,
   "PlayVoice": false,
   "Debug": false,
-  "Update": "https://2langs.com/data/update.json"
+  "Update": "https://2langs.com/data/update.json",
+  "Font": "Arial"
 }

--- a/GI-Subtitles/GI-Subtitles.csproj
+++ b/GI-Subtitles/GI-Subtitles.csproj
@@ -144,6 +144,9 @@
     <Compile Include="Services\Translation\OptimizedMatcherCache.cs" />
     <Compile Include="Services\Translation\MatchDataLoader.cs" />
     <Compile Include="Core\Screen\ScreenInfo.cs" />
+    <Compile Include="Views\Font.xaml.cs">
+      <DependentUpon>Font.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SettingsWindow.xaml.cs">
       <DependentUpon>Views\SettingsWindow.xaml</DependentUpon>
     </Compile>
@@ -167,6 +170,7 @@
     <Compile Include="Models\HotkeyData.cs" />
     <Compile Include="Models\OCRTestResult.cs" />
     <Compile Include="Services\Update\UpdateChecker.cs" />
+    <Page Include="Views\Font.xaml" />
     <Page Include="Views\MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/GI-Subtitles/Resources/Strings.zh-CN.xaml
+++ b/GI-Subtitles/Resources/Strings.zh-CN.xaml
@@ -82,6 +82,7 @@
     <sys:String x:Key="Btn_SecondRegion" xmlns:sys="clr-namespace:System;assembly=mscorlib">添加第二识别区域</sys:String>
     <sys:String x:Key="Btn_DeleteSecondRegion_Tooltip" xmlns:sys="clr-namespace:System;assembly=mscorlib">删除第二识别区域</sys:String>
     <sys:String x:Key="Btn_Voice" xmlns:sys="clr-namespace:System;assembly=mscorlib">支线配音</sys:String>
+    <sys:String x:Key="Btn_SubtitleFont" xmlns:sys="clr-namespace:System;assembly=mscorlib">更改字体</sys:String>
 
     <!-- Notify Icon Menu -->
     <sys:String x:Key="Tray_FontSize" xmlns:sys="clr-namespace:System;assembly=mscorlib">字号选择</sys:String>
@@ -114,4 +115,12 @@
     <!-- Data Warnings -->
     <sys:String x:Key="Incomplete_Data_Warning" xmlns:sys="clr-namespace:System;assembly=mscorlib">检测到《原神》当前使用的语言包缺少 Medium 数据，部分文本将无法识别。请点击下方按钮下载并合并 Medium 数据。</sys:String>
     <sys:String x:Key="Data_Repair" xmlns:sys="clr-namespace:System;assembly=mscorlib">下载并合并 Medium 数据</sys:String>
+    
+    <!-- Font Preview -->
+    <sys:String x:Key="FontPreviewWindow" xmlns:sys="clr-namespace:System;assembly=mscorlib">字体</sys:String>
+    <sys:String x:Key="SampleText" xmlns:sys="clr-namespace:System;assembly=mscorlib">测试文本</sys:String>
+    <sys:String x:Key="FontName" xmlns:sys="clr-namespace:System;assembly=mscorlib">字体</sys:String>
+    <sys:String x:Key="Preview" xmlns:sys="clr-namespace:System;assembly=mscorlib">字体预览</sys:String>
+    <sys:String x:Key="Btn_FontPreviewSelect" xmlns:sys="clr-namespace:System;assembly=mscorlib">选择</sys:String>
+    <sys:String x:Key="Btn_FontPreviewCancel" xmlns:sys="clr-namespace:System;assembly=mscorlib">取消</sys:String>
 </ResourceDictionary>

--- a/GI-Subtitles/Views/Font.xaml
+++ b/GI-Subtitles/Views/Font.xaml
@@ -1,0 +1,85 @@
+﻿<Window x:Class="GI_Subtitles.Views.Font"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:local="clr-namespace:GI_Subtitles.Views"
+        mc:Ignorable="d"
+        Title="{DynamicResource FontPreviewWindow}" Height="450" Width="800">
+    
+    <Window.Resources>
+        <!-- Unified button style -->
+        <Style TargetType="Button" x:Key="PrimaryButton">
+            <Setter Property="MinWidth" Value="90"/>
+            <Setter Property="Height" Value="30"/>
+            <Setter Property="Padding" Value="10,4"/>
+        </Style>
+    </Window.Resources>
+    
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        
+        <Grid Grid.Row="0" Margin="0, 0, 0, 10">
+            <StackPanel Orientation="Horizontal" Margin="0,0,8,0">
+                <TextBlock Text="{DynamicResource SampleText}" Margin="0,0,8,0"/>
+                <TextBox
+                    Name="SampleTextTextBox"
+                    Width="300"
+                    VerticalContentAlignment="Center"
+                    Text="测试文本 Sample Text 123"
+                    TextChanged="SampleTextTextBox_OnTextChanged"/>
+            </StackPanel>
+        </Grid>
+        
+        <Grid Grid.Row="1" Margin="0, 0, 0, 10">
+            <ListView 
+                Name="FontListView"
+                Loaded="FontListView_Loaded"
+                MaxHeight="300">
+                <ListView.View>
+                    <GridView>
+                        <GridViewColumn
+                            x:Name="FontNameCol"
+                            Header="{DynamicResource FontName}">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding FontName}"/>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+
+                        <GridViewColumn
+                            x:Name="FontPreviewCol"
+                            Header="{DynamicResource Preview}">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock
+                                        Text="{Binding PreviewText}"
+                                        FontFamily="{Binding FontName}"
+                                        FontSize="18"/>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+
+                    </GridView>
+                </ListView.View>
+            </ListView>
+        </Grid>
+        
+        <WrapPanel Grid.Row="2" HorizontalAlignment="Right" >
+            <Button
+                Content="{DynamicResource Btn_FontPreviewSelect}"
+                Style="{StaticResource PrimaryButton}"
+                Click="Btn_FontPreviewSelect_OnClick"
+                Margin="0, 0, 20, 0"/>
+            <Button
+                Content="{DynamicResource Btn_FontPreviewCancel}"
+                Style="{StaticResource PrimaryButton}"
+                Click="Btn_FontPreviewCancel_OnClick"/>
+        </WrapPanel>
+    </Grid>
+</Window>

--- a/GI-Subtitles/Views/Font.xaml.cs
+++ b/GI-Subtitles/Views/Font.xaml.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using GI_Subtitles.Core.Config;
+
+namespace GI_Subtitles.Views
+{
+    public class ViewListRow
+    {
+        public string FontName { get; set; }
+        public string PreviewText { get; set; }
+    }
+
+    public partial class Font : Window
+    {
+        private ObservableCollection<ViewListRow> Row { get; set; }
+        
+        public Font()
+        {
+            InitializeComponent();
+            
+            Row = new ObservableCollection<ViewListRow>();
+            AddFontListViewItems();
+            FontListView.ItemsSource = Row;
+
+            var prevFont = Config.Get<string>("Font");
+            var prevFontIndexInList = Row.IndexOf(Row.First(t => t.FontName == prevFont));
+            if (prevFontIndexInList != -1)
+            {
+                FontListView.SelectedIndex = prevFontIndexInList;
+                FontListView.ScrollIntoView(FontListView.Items[prevFontIndexInList]);
+            }
+        }
+
+        private void FontListView_Loaded(object sender, RoutedEventArgs e)
+        {    
+            double totalWidth = FontListView.ActualWidth;
+            FontNameCol.Width = totalWidth * 0.20;
+            FontPreviewCol.Width = totalWidth * 0.75;
+        }
+
+        private void AddFontListViewItems()
+        {
+            var fonts = Fonts.SystemFontFamilies.Select(f => f.Source).ToList();
+            foreach (var fontName in fonts)
+            {
+                var item = new ViewListRow
+                {
+                    FontName = fontName,
+                    PreviewText = SampleTextTextBox.Text,
+                };
+                Row.Add(item);
+            }
+        }
+
+        private void SampleTextTextBox_OnTextChanged(object sender, TextChangedEventArgs e)
+        {
+            // TODO
+            // try...catch... is not a good way to handle the issue that the NullReferenceException is thrown because
+            // a TextBox control is created and the method triggered while the TextBox itself not initialized
+            // See the URL for a better solution: https://stackoverflow.com/a/33599469
+            try
+            {
+                Row = new ObservableCollection<ViewListRow>();
+                AddFontListViewItems();
+                FontListView.ItemsSource = Row;
+            }
+            catch(NullReferenceException)
+            { /* Do nothing */ }
+        }
+
+        private void Btn_FontPreviewSelect_OnClick(object sender, RoutedEventArgs e)
+        {
+            var selectedItem = (ViewListRow)FontListView.SelectedItem;
+            if (selectedItem != null)
+            {
+                Config.Set("Font", selectedItem.FontName);
+                var result = MessageBox.Show(
+                    $"Subtitle font was set to: {selectedItem.FontName}\nClose the \"Font\" window?",
+                    "Font Set",
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Asterisk);
+                if (result == MessageBoxResult.Yes)
+                    Close();
+            }
+            else
+            {
+                MessageBox.Show(
+                    "Choose a font",
+                    "No Selection",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+        }
+
+        private void Btn_FontPreviewCancel_OnClick(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/GI-Subtitles/Views/SettingsWindow.xaml
+++ b/GI-Subtitles/Views/SettingsWindow.xaml
@@ -370,6 +370,7 @@
                                        VerticalAlignment="Center"/>
                         </Button>
                         <Button Content="{DynamicResource Btn_OpenFolder}" Margin="0,0,20,0" Click="OpenAppDataFolder_Click"/>
+                        <Button Content="{DynamicResource Btn_SubtitleFont}" Click="FontPreview_Click"></Button>
                     </WrapPanel>
 
                 </Grid>

--- a/GI-Subtitles/Views/SettingsWindow.xaml.cs
+++ b/GI-Subtitles/Views/SettingsWindow.xaml.cs
@@ -2135,5 +2135,12 @@ namespace GI_Subtitles.Views
             }
             e.Handled = true;
         }
+
+        private void FontPreview_Click(object sender, RoutedEventArgs e)
+        {
+            Font font = new Font();
+            this.Close(); // FIXME font view window should be shown in front of the setting window
+            font.ShowDialog();
+        }
     }
 }


### PR DESCRIPTION
Implement new functionality allowing users to customize the font of the subtitle.

## Solution
- Add a font preview window.
- Add a new field `"Font": "Arial"` in the `Config.json`. The Arial font is served as a default font.

## Testing
Manually tests were done. The new function worked as intended.