### PR TITLE
fix: complete subtitle font customization

### DIFF
--- a/GI-Subtitles/App.xaml.cs
+++ b/GI-Subtitles/App.xaml.cs
@@ -42,14 +42,34 @@ namespace GI_Subtitles
 
             // Load UI language resources before MainWindow is created
             LoadUILanguageResources();
-            ApplySubtitleFont(Config.Get("Font", "Arial"));
+            string configuredFont = Config.Get("Font", "Arial");
+            string resolvedFont = ResolveSubtitleFontName(configuredFont);
+            if (!string.Equals(configuredFont, resolvedFont, StringComparison.Ordinal))
+            {
+                Config.Set("Font", resolvedFont);
+            }
+            ApplySubtitleFont(resolvedFont);
 
             base.OnStartup(e);
         }
 
         public static void ApplySubtitleFont(string fontName)
         {
-            Current.Resources["SubtitleFontFamily"] = new FontFamily(fontName);
+            Current.Resources["SubtitleFontFamily"] = new FontFamily(ResolveSubtitleFontName(fontName));
+        }
+
+        public static string ResolveSubtitleFontName(string fontName)
+        {
+            FontFamily selectedFont = Fonts.SystemFontFamilies.FirstOrDefault(
+                font => string.Equals(font.Source, fontName, StringComparison.OrdinalIgnoreCase));
+            if (selectedFont != null)
+            {
+                return selectedFont.Source;
+            }
+
+            FontFamily arial = Fonts.SystemFontFamilies.FirstOrDefault(
+                font => string.Equals(font.Source, "Arial", StringComparison.OrdinalIgnoreCase));
+            return arial?.Source ?? SystemFonts.MessageFontFamily.Source;
         }
 
         /// <summary>

--- a/GI-Subtitles/App.xaml.cs
+++ b/GI-Subtitles/App.xaml.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Windows;
+using System.Windows.Media;
 using System.Globalization;
 using GI_Subtitles.Core.Config;
 using GI_Subtitles.Common;
@@ -41,8 +42,14 @@ namespace GI_Subtitles
 
             // Load UI language resources before MainWindow is created
             LoadUILanguageResources();
+            ApplySubtitleFont(Config.Get("Font", "Arial"));
 
             base.OnStartup(e);
+        }
+
+        public static void ApplySubtitleFont(string fontName)
+        {
+            Current.Resources["SubtitleFontFamily"] = new FontFamily(fontName);
         }
 
         /// <summary>

--- a/GI-Subtitles/Resources/Strings.en-US.xaml
+++ b/GI-Subtitles/Resources/Strings.en-US.xaml
@@ -74,6 +74,7 @@
     <sys:String x:Key="Btn_SecondRegion" xmlns:sys="clr-namespace:System;assembly=mscorlib">Add Secondary Recognition Region</sys:String>
     <sys:String x:Key="Btn_DeleteSecondRegion_Tooltip" xmlns:sys="clr-namespace:System;assembly=mscorlib">Delete secondary recognition region</sys:String>
     <sys:String x:Key="Btn_Voice" xmlns:sys="clr-namespace:System;assembly=mscorlib">Voice</sys:String>
+    <sys:String x:Key="Btn_SubtitleFont" xmlns:sys="clr-namespace:System;assembly=mscorlib">Change Font</sys:String>
 
     <!-- Tray menu -->
     <sys:String x:Key="Tray_FontSize" xmlns:sys="clr-namespace:System;assembly=mscorlib">Font Size</sys:String>
@@ -106,4 +107,16 @@
     <!-- Data Warnings -->
     <sys:String x:Key="Incomplete_Data_Warning" xmlns:sys="clr-namespace:System;assembly=mscorlib">Detected that the currently used Genshin language packs are missing Medium data. Some text cannot be recognized until you download and merge the Medium files.</sys:String>
     <sys:String x:Key="Data_Repair" xmlns:sys="clr-namespace:System;assembly=mscorlib">Download and Merge Medium Data</sys:String>
+
+    <!-- Font Preview -->
+    <sys:String x:Key="FontPreviewWindow" xmlns:sys="clr-namespace:System;assembly=mscorlib">Font</sys:String>
+    <sys:String x:Key="SampleText" xmlns:sys="clr-namespace:System;assembly=mscorlib">Sample Text</sys:String>
+    <sys:String x:Key="FontName" xmlns:sys="clr-namespace:System;assembly=mscorlib">Font</sys:String>
+    <sys:String x:Key="Preview" xmlns:sys="clr-namespace:System;assembly=mscorlib">Preview</sys:String>
+    <sys:String x:Key="Btn_FontPreviewSelect" xmlns:sys="clr-namespace:System;assembly=mscorlib">Select</sys:String>
+    <sys:String x:Key="Btn_FontPreviewCancel" xmlns:sys="clr-namespace:System;assembly=mscorlib">Cancel</sys:String>
+    <sys:String x:Key="FontSetMessage" xmlns:sys="clr-namespace:System;assembly=mscorlib">Subtitle font was set to: {0}&#10;Close the Font window?</sys:String>
+    <sys:String x:Key="FontSetTitle" xmlns:sys="clr-namespace:System;assembly=mscorlib">Font Set</sys:String>
+    <sys:String x:Key="FontChoosePrompt" xmlns:sys="clr-namespace:System;assembly=mscorlib">Choose a font</sys:String>
+    <sys:String x:Key="FontNoSelectionTitle" xmlns:sys="clr-namespace:System;assembly=mscorlib">No Selection</sys:String>
 </ResourceDictionary>

--- a/GI-Subtitles/Resources/Strings.ja-JP.xaml
+++ b/GI-Subtitles/Resources/Strings.ja-JP.xaml
@@ -74,6 +74,7 @@
     <sys:String x:Key="Btn_SecondRegion" xmlns:sys="clr-namespace:System;assembly=mscorlib">第2認識領域を追加</sys:String>
     <sys:String x:Key="Btn_DeleteSecondRegion_Tooltip" xmlns:sys="clr-namespace:System;assembly=mscorlib">第2認識領域を削除</sys:String>
     <sys:String x:Key="Btn_Voice" xmlns:sys="clr-namespace:System;assembly=mscorlib">音声</sys:String>
+    <sys:String x:Key="Btn_SubtitleFont" xmlns:sys="clr-namespace:System;assembly=mscorlib">字幕フォントを変更</sys:String>
 
     <!-- トレイ メニュー -->
     <sys:String x:Key="Tray_FontSize" xmlns:sys="clr-namespace:System;assembly=mscorlib">フォントサイズ</sys:String>
@@ -106,4 +107,16 @@
     <!-- Data Warnings -->
     <sys:String x:Key="Incomplete_Data_Warning" xmlns:sys="clr-namespace:System;assembly=mscorlib">現在使用中の『原神』言語パックに Medium データが不足しています。このままでは一部のテキストを認識できません。下のボタンから Medium データをダウンロードして結合してください。</sys:String>
     <sys:String x:Key="Data_Repair" xmlns:sys="clr-namespace:System;assembly=mscorlib">Medium データを取得して結合</sys:String>
+
+    <!-- フォントプレビュー -->
+    <sys:String x:Key="FontPreviewWindow" xmlns:sys="clr-namespace:System;assembly=mscorlib">フォント</sys:String>
+    <sys:String x:Key="SampleText" xmlns:sys="clr-namespace:System;assembly=mscorlib">サンプルテキスト</sys:String>
+    <sys:String x:Key="FontName" xmlns:sys="clr-namespace:System;assembly=mscorlib">フォント名</sys:String>
+    <sys:String x:Key="Preview" xmlns:sys="clr-namespace:System;assembly=mscorlib">プレビュー</sys:String>
+    <sys:String x:Key="Btn_FontPreviewSelect" xmlns:sys="clr-namespace:System;assembly=mscorlib">選択</sys:String>
+    <sys:String x:Key="Btn_FontPreviewCancel" xmlns:sys="clr-namespace:System;assembly=mscorlib">キャンセル</sys:String>
+    <sys:String x:Key="FontSetMessage" xmlns:sys="clr-namespace:System;assembly=mscorlib">字幕フォントを {0} に設定しました。&#10;フォントウィンドウを閉じますか？</sys:String>
+    <sys:String x:Key="FontSetTitle" xmlns:sys="clr-namespace:System;assembly=mscorlib">フォントを設定しました</sys:String>
+    <sys:String x:Key="FontChoosePrompt" xmlns:sys="clr-namespace:System;assembly=mscorlib">フォントを選択してください</sys:String>
+    <sys:String x:Key="FontNoSelectionTitle" xmlns:sys="clr-namespace:System;assembly=mscorlib">フォント未選択</sys:String>
 </ResourceDictionary>

--- a/GI-Subtitles/Resources/Strings.zh-CN.xaml
+++ b/GI-Subtitles/Resources/Strings.zh-CN.xaml
@@ -123,4 +123,8 @@
     <sys:String x:Key="Preview" xmlns:sys="clr-namespace:System;assembly=mscorlib">字体预览</sys:String>
     <sys:String x:Key="Btn_FontPreviewSelect" xmlns:sys="clr-namespace:System;assembly=mscorlib">选择</sys:String>
     <sys:String x:Key="Btn_FontPreviewCancel" xmlns:sys="clr-namespace:System;assembly=mscorlib">取消</sys:String>
+    <sys:String x:Key="FontSetMessage" xmlns:sys="clr-namespace:System;assembly=mscorlib">字幕字体已设置为：{0}&#10;是否关闭字体窗口？</sys:String>
+    <sys:String x:Key="FontSetTitle" xmlns:sys="clr-namespace:System;assembly=mscorlib">字体已设置</sys:String>
+    <sys:String x:Key="FontChoosePrompt" xmlns:sys="clr-namespace:System;assembly=mscorlib">请选择一种字体</sys:String>
+    <sys:String x:Key="FontNoSelectionTitle" xmlns:sys="clr-namespace:System;assembly=mscorlib">未选择字体</sys:String>
 </ResourceDictionary>

--- a/GI-Subtitles/Views/Font.xaml.cs
+++ b/GI-Subtitles/Views/Font.xaml.cs
@@ -80,8 +80,8 @@ namespace GI_Subtitles.Views
                 Config.Set("Font", selectedItem.FontName);
                 App.ApplySubtitleFont(selectedItem.FontName);
                 var result = MessageBox.Show(
-                    $"Subtitle font was set to: {selectedItem.FontName}\nClose the \"Font\" window?",
-                    "Font Set",
+                    string.Format(GetLocalizedString("FontSetMessage"), selectedItem.FontName),
+                    GetLocalizedString("FontSetTitle"),
                     MessageBoxButton.YesNo,
                     MessageBoxImage.Asterisk);
                 if (result == MessageBoxResult.Yes)
@@ -90,8 +90,8 @@ namespace GI_Subtitles.Views
             else
             {
                 MessageBox.Show(
-                    "Choose a font",
-                    "No Selection",
+                    GetLocalizedString("FontChoosePrompt"),
+                    GetLocalizedString("FontNoSelectionTitle"),
                     MessageBoxButton.OK,
                     MessageBoxImage.Error);
             }
@@ -100,6 +100,11 @@ namespace GI_Subtitles.Views
         private void Btn_FontPreviewCancel_OnClick(object sender, RoutedEventArgs e)
         {
             Close();
+        }
+
+        private static string GetLocalizedString(string key)
+        {
+            return Application.Current.TryFindResource(key) as string ?? key;
         }
     }
 }

--- a/GI-Subtitles/Views/Font.xaml.cs
+++ b/GI-Subtitles/Views/Font.xaml.cs
@@ -26,8 +26,10 @@ namespace GI_Subtitles.Views
             AddFontListViewItems();
             FontListView.ItemsSource = Row;
 
-            var prevFont = Config.Get<string>("Font");
-            var prevFontIndexInList = Row.IndexOf(Row.First(t => t.FontName == prevFont));
+            var prevFont = App.ResolveSubtitleFontName(Config.Get("Font", "Arial"));
+            var previousRow = Row.FirstOrDefault(
+                row => string.Equals(row.FontName, prevFont, StringComparison.OrdinalIgnoreCase));
+            var prevFontIndexInList = Row.IndexOf(previousRow);
             if (prevFontIndexInList != -1)
             {
                 FontListView.SelectedIndex = prevFontIndexInList;

--- a/GI-Subtitles/Views/Font.xaml.cs
+++ b/GI-Subtitles/Views/Font.xaml.cs
@@ -78,6 +78,7 @@ namespace GI_Subtitles.Views
             if (selectedItem != null)
             {
                 Config.Set("Font", selectedItem.FontName);
+                App.ApplySubtitleFont(selectedItem.FontName);
                 var result = MessageBox.Show(
                     $"Subtitle font was set to: {selectedItem.FontName}\nClose the \"Font\" window?",
                     "Font Set",

--- a/GI-Subtitles/Views/MainWindow.xaml
+++ b/GI-Subtitles/Views/MainWindow.xaml
@@ -22,6 +22,7 @@
         </Button>
         <TextBox x:Name="SubtitleText"
                  TextWrapping="Wrap"
+                 FontFamily="{DynamicResource SubtitleFontFamily}"
                  Foreground="White"
                  TextAlignment="Center"
                  FontWeight="Bold"
@@ -42,6 +43,7 @@
             </StackPanel.RenderTransform>
             <TextBlock x:Name="HeaderText"
                        TextWrapping="Wrap"
+                       FontFamily="{DynamicResource SubtitleFontFamily}"
                        Foreground="White"
                        TextAlignment="Center"
                        FontWeight="Bold"
@@ -50,6 +52,7 @@
                        Visibility="Collapsed"/>
             <TextBlock x:Name="DialogueChoiceText"
                        TextWrapping="Wrap"
+                       FontFamily="{DynamicResource SubtitleFontFamily}"
                        Foreground="{Binding ElementName=HeaderText, Path=Foreground}"
                        TextAlignment="Center"
                        FontWeight="Bold"

--- a/GI-Subtitles/Views/SettingsWindow.xaml.cs
+++ b/GI-Subtitles/Views/SettingsWindow.xaml.cs
@@ -2138,8 +2138,11 @@ namespace GI_Subtitles.Views
 
         private void FontPreview_Click(object sender, RoutedEventArgs e)
         {
-            Font font = new Font();
-            this.Close(); // FIXME font view window should be shown in front of the setting window
+            Font font = new Font
+            {
+                Owner = this,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             font.ShowDialog();
         }
     }


### PR DESCRIPTION
## Summary
- Apply the selected font to live subtitle and dialogue elements.
- Add font-picker translations for Chinese, English, and Japanese.
- Keep the settings window open while choosing a font.
- Fall back safely when the configured font is unavailable.

## Validation
- Visual Studio MSBuild: GI-Subtitles.csproj Debug build passed with 0 warnings and 0 errors.

This PR follows the already merged #15 feature commit.