### PR TITLE
chore: add VS MSBuild build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,10 @@ Genshin-Subtitles enables players to:
 
 ### Building
 
-```bash
-# Restore NuGet packages
-nuget restore GI-Subtitles.sln
-
-# Build Release version
-msbuild GI-Subtitles.sln -t:GI-Subtitles:Rebuild -p:Configuration=Release -p:Platform=x64
+```powershell
+# Restore packages.config, OCR models, and build with Visual Studio MSBuild.
+# Do not use `dotnet build`: this solution is packages.config + .NET Framework.
+pwsh -File scripts/Build.ps1 -Configuration Release
 ```
 
 ### Running Tests

--- a/README_CN.md
+++ b/README_CN.md
@@ -96,12 +96,10 @@ https://www.bilibili.com/video/BV1qxtjeME7e/
 
 ### 构建
 
-```bash
-# 还原 NuGet 包
-nuget restore GI-Subtitles.sln
-
-# 构建 Release 版本
-msbuild GI-Subtitles.sln -t:GI-Subtitles:Rebuild -p:Configuration=Release -p:Platform=x64
+```powershell
+# 还原 packages.config、OCR 模型，并用 Visual Studio MSBuild 构建。
+# 不要使用 `dotnet build`：本解决方案是 packages.config + .NET Framework。
+pwsh -File scripts/Build.ps1 -Configuration Release
 ```
 
 ### 测试

--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -1,0 +1,73 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Debug",
+    [string]$Platform = "x64",
+    [string]$Target = "GI-Subtitles",
+    [switch]$SkipRestore,
+    [switch]$SkipOcrModels
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..")).Path
+$solutionPath = Join-Path $repoRoot "GI-Subtitles.sln"
+
+function Get-MsBuildPath {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (-not (Test-Path -LiteralPath $vswhere)) {
+        throw "vswhere.exe was not found. Install Visual Studio Build Tools with the MSBuild component."
+    }
+
+    $candidates = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe"
+    if (-not $candidates) {
+        throw "MSBuild.exe was not found. Install Visual Studio with the .NET desktop development workload."
+    }
+
+    $preferred = @($candidates | Where-Object { $_ -match '\\MSBuild\\Current\\Bin\\MSBuild\.exe$' })
+    if ($preferred.Count -gt 0) {
+        return $preferred[0]
+    }
+
+    return @($candidates)[0]
+}
+
+function Get-NugetPath {
+    $onPath = Get-Command nuget -ErrorAction SilentlyContinue
+    if ($onPath) {
+        return $onPath.Source
+    }
+
+    $cacheDir = Join-Path $env:LOCALAPPDATA "GI-Subtitles"
+    $nugetPath = Join-Path $cacheDir "nuget.exe"
+    if (Test-Path -LiteralPath $nugetPath) {
+        return $nugetPath
+    }
+
+    New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+    Write-Host "Downloading nuget.exe to $nugetPath"
+    Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile $nugetPath -UseBasicParsing
+    return $nugetPath
+}
+
+$msbuild = Get-MsBuildPath
+Write-Host "MSBuild: $msbuild"
+
+if (-not $SkipRestore) {
+    $nuget = Get-NugetPath
+    Write-Host "NuGet: $nuget"
+    & $nuget restore $solutionPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "nuget restore failed with exit code $LASTEXITCODE"
+    }
+}
+
+if (-not $SkipOcrModels) {
+    & (Join-Path $PSScriptRoot "Restore-OcrModels.ps1")
+}
+
+Write-Host "Building $Target ($Configuration|$Platform)"
+& $msbuild $solutionPath "-t:${Target}:Rebuild" "-p:Configuration=$Configuration" "-p:Platform=$Platform"
+if ($LASTEXITCODE -ne 0) {
+    throw "msbuild failed with exit code $LASTEXITCODE"
+}


### PR DESCRIPTION
## Summary
- Add `scripts/Build.ps1` to build with Visual Studio MSBuild.
- Document the PowerShell build path in README / README_CN **build sections only**.

## Related
- Closes #18
- Series: **PR-01** (independent chore; Ready)
- Sibling chore PR: #30

## Validation
- `pwsh -File scripts/Build.ps1 -Configuration Release` builds `GI-Subtitles` (ignore unrelated WixSharp SDK noise if present in the environment).
