### PR TITLE
chore: guard website deploy to upstream repository only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,9 @@ jobs:
 
   deploy-website:
     name: Deploy website downloads
-    if: ${{ (github.event_name == 'push' || inputs.publish) && !contains(github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name, '-') }}
+    # Upstream only: forks lack the deploy secrets and must never touch the
+    # stable channel, even if a bare (un-hyphenated) tag is pushed by accident.
+    if: ${{ github.repository == 'qew21/Genshin-Subtitles' && (github.event_name == 'push' || inputs.publish) && !contains(github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name, '-') }}
     needs: release
     runs-on: ubuntu-24.04
     environment: production


### PR DESCRIPTION
## Summary
- Gate `deploy-website` so it runs only when `github.repository == 'qew21/Genshin-Subtitles'`.
- Comment notes that forks must not deploy the stable website channel.

## Related
- Closes #19
- Series: **PR-02** (independent chore; Ready)
- Sibling chore PR: #29

## Validation
- Workflow YAML still parses.
- Diff is limited to the deploy-website repository guard (no fork release-note branding).
